### PR TITLE
Since aur has moved to git, the tarball url has changed

### DIFF
--- a/blocks/_lib/helpers.sh
+++ b/blocks/_lib/helpers.sh
@@ -217,7 +217,7 @@ else
     for req in wget git jshon; do
         command -v $req >/dev/null 2>&1 || _installpkg $req;
     done
-    wget "https://aur.archlinux.org/packages/${pkg:0:2}/${pkg}/${pkg}.tar.gz";
+    wget "https://aur.archlinux.org/cgit/aur.git/snapshot/${pkg}.tar.gz"
     tar -xzvf ${pkg}.tar.gz; cd ${pkg};
     makepkg --asroot -si --noconfirm; cd "$orig"; rm -rf $build_dir;
     $AURHELPER -S --noconfirm "$@";


### PR DESCRIPTION
Updated to use the snapshot url for tarballs instead of the old schema.
